### PR TITLE
Changes to Trivial Implementation

### DIFF
--- a/specification_draft2.md
+++ b/specification_draft2.md
@@ -42,7 +42,7 @@ The receiver MUST accept newline as line delimiter `\n` (0x0A) as well as carria
 
 #### 3.2.1 Trivial Implementation
 
-A simple implementation is to accumulate received data. Every time a line ending is encountered, an attempt MUST be made to parse the accumulated data (up to the last line ending) into lines.  Data beyond the last line ending must be retained.
+A simple implementation is to accumulate received data. Every time a line ending is encountered, an attempt MUST be made to parse the accumulated data (up to the last line ending) into lines.  Data beyond the last line ending must be retained for future parsing.
 
 If the data source closes, whithout a terminating line ending, an error MUST be generated for the application to consume.
 

--- a/specification_draft2.md
+++ b/specification_draft2.md
@@ -40,15 +40,15 @@ All serialized data MUST use the UTF8 encoding.
 
 The receiver MUST accept newline as line delimiter `\n` (0x0A) as well as carriage return and newline `\r\n` (0x0D0A). The receiver SHOULD silently ignore empty lines, e.g. `\n\n`.
 
-#### 3.2.1 Trivial Implementation
+#### 3.2.1 Trivial Library Implementation
 
-A simple implementation is to accumulate received data. Every time a line ending is encountered, an attempt MUST be made to parse the accumulated data (up to the last line ending) into lines.  Data beyond the last line ending must be retained for future parsing.
+A simple implementation is to accumulate received data. Every time a line ending is encountered, an attempt MUST be made to parse the accumulated data (up to and including the last line ending) into lines.  Data beyond the last line ending must be retained for future parsing.
 
 If the data source closes, whithout a terminating line ending, an error MUST be generated for the application to consume.
 
-Each line, between (and including) the first '{' and the last '}' MUST be parsed as a JSON object, and given to the application.  Unparseable lines MAY be silently ignored, or MAY generate errors for the application to handle.
+Each line, between (and including) the first '{' and the last '}' MUST be parsed as a JSON object, and given to the application.  Unparseable lines MUST generate errors for the application to handle to ignore or handle.
 
-Note: Ignoring data outside of the outermost curly brackets gives Telnet-client compatibility for very little extra processing.  (The telnet protocol includes additional control sequences in with data, that can confuse JSON parsers.  The use of telnet to test NDJSON-based protocols is highly useful for Windows users without `nc`.)
+Note: Ignoring data outside of the outermost curly brackets gives Telnet-client compatibility for very little extra processing.  (The telnet protocol includes additional control sequences in the data stream, which can confuse JSON parsers.  The use of telnet to test NDJSON-based protocols is highly useful for Windows users without `nc`.)
 
 ### 3.3 MIME Type and File Extensions
 

--- a/specification_draft2.md
+++ b/specification_draft2.md
@@ -42,9 +42,13 @@ The receiver MUST accept newline as line delimiter `\n` (0x0A) as well as carria
 
 #### 3.2.1 Trivial Implementation
 
-A simple implementation is to accumulate received lines. Every time a line ending is encountered, an attempt MUST be made to parse the accumulated lines into a JSON object.
+A simple implementation is to accumulate received data. Every time a line ending is encountered, an attempt MUST be made to parse the accumulated data (up to the last line ending) into lines.  Data beyond the last line ending must be retained.
 
-If the parsing of the accumulated lines is successful, the accumulated lines MUST be discarded and the parsed object given to the application code.
+If the data source closes, whithout a terminating line ending, an error MUST be generated for the application to consume.
+
+Each line, between (and including) the first '{' and the last '}' MUST be parsed as a JSON object, and given to the application.  Unparseable lines MAY be silently ignored, or MAY generate errors for the application to handle.
+
+Note: Ignoring data outside of the outermost curly brackets gives Telnet-client compatibility for very little extra processing.  (The telnet protocol includes additional control sequences in with data, that can confuse JSON parsers.  The use of telnet to test NDJSON-based protocols is highly useful for Windows users without `nc`.)
 
 ### 3.3 MIME Type and File Extensions
 


### PR DESCRIPTION
- Changed to reflect that multi-line JSON does not need to be accepted.
- Added constraint that JSON parsing should only be done between (and including) outermost curly brackets found on each line.  This is a fix I needed to handle a client who was testing with a particular Windows Telnet client.

Question: Are all NDJSON lines assumed to contain JSON objects (which is all I use, or have seen in the wild), or could they be single JSON primitives (a number, string or bool) or Arrays?  In this case the curly bracket functionality won't work.

I think that using only JSON primitives can be ruled out as a use case, as that's a degenerate case, but newline separated Arrays or JSON might be a real use case.
