### PR TITLE
Error handling / Naming

### DIFF
--- a/specification_draft2.md
+++ b/specification_draft2.md
@@ -30,15 +30,18 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ## 3. Functional Specification
 
-### 3.1 Sending
+### 3.1 Serialization
 
 Each JSON text MUST conform to the \[[RFC7159]\]) standard and MUST be written to the stream followed by the newline character `\n` (0x0A). The newline charater MAY be preceeded by a carriage return `\r` (0x0D). The JSON texts MUST NOT contain newlines or carriage returns.
 
 All serialized data MUST use the UTF8 encoding.
 
-### 3.2 Receiving
+### 3.2 Parsing
 
-The receiver MUST accept newline as line delimiter `\n` (0x0A) as well as carriage return and newline `\r\n` (0x0D0A). The receiver SHOULD silently ignore empty lines, e.g. `\n\n`.
+The parser MUST accept newline as line delimiter `\n` (0x0A) as well as carriage return and newline `\r\n` (0x0D0A). 
+
+If the JSON text is not parseable, the parser SHOULD raise an error. However, the parser MAY silently ignore empty lines, e.g. `\n\n`. This behavior 
+MUST be documented and SHOULD be configurable by the user of the parser.
 
 #### 3.2.1 Trivial Implementation
 


### PR DESCRIPTION
I tried to make it a little bit more clear that empty lines are actually errors (see  #8) and made it optional not recommended to silently ignore empty lines. Also I added that this should be clearly documented and configurable.

I also changed the names sending/receiving to serialize/parse, because I feel like that is the important part of the spec. 
