### PR TITLE
add a liquid header for jekyll friendliness

### DIFF
--- a/specification_draft2.md
+++ b/specification_draft2.md
@@ -1,6 +1,11 @@
-# NDJSON - Newline delimited JSON
+---
+title: NDJSON - Newline delimited JSON
+version: Draft 2
+last_update: 2014-09-25
+created: 2013-07-05
+---
 
-# Draft 2 (2014-09-25)
+# NDJSON - Newline delimited JSON
 
 A standard for delimiting JSON in stream protocols.
 


### PR DESCRIPTION
This adds a liquid header to the spec markdown. The reason why this is useful is that it lets a jekyll-based site like dataprotocols.org include the spec cleanly as a git submodule, rather than needing to copy and tweak the file manually. It is a bit strange to modify a spec file to benefit a random website, so no problem if you'd rather keep the spec as pure markdown. But since the header [displays ok within github](https://github.com/paulfitz/ndjson-spec/blob/liquid/specification_draft2.md) I thought I'd at least suggest it.

I moved some version information into the header since it didn't seem to reduce readability and makes it easier to consistently format that information.

Thanks!
