### PR TITLE
add index.md symlink to simplify use with jekyll

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,0 +1,1 @@
+README.md


### PR DESCRIPTION
I'm adding the ndjon spec to dataprotocols.org, and adding this symlink would let us serve the spec at http://dataprotocols.org/ndjson/ rather than http://dataprotocols.org/ndjson/README.html - see https://github.com/dataprotocols/dataprotocols/issues/79#issuecomment-59664099. Github displays a symlink in a clean way (see https://github.com/paulfitz/ndjson-spec/tree/symlink) so hopefully this wouldn't cause any confusion. I admit I'm not sure what happens on Windows checkouts though.
